### PR TITLE
SCons: Fix setting RPATH for ffmpeg libs

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -12,7 +12,7 @@ env = Environment(variables=opts)
 
 if env['debug']:
     env.Append(CPPFLAGS=['-g'])
-env.Append(LINKFLAG='-Wl,-rpath,./lib')
+env.Append(RPATH=env.Literal('\\$$ORIGIN/lib'))
 
 env.Append(CPPPATH=['#test/addons/bin/'+env['platform']+'/include'])
 env.Append(CPPPATH=['#godot_include'])


### PR DESCRIPTION
Works fine on Linux, might work on other platforms too thanks to
using the RPATH env variable from SCons (which should expand to
the platform-specific LINKFLAGS).