### PR TITLE
Fix audio synchronization and frame dropping performance.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -20,7 +20,7 @@ lib_path = lib_prefix + '/lib'
 include_path = lib_prefix + '/include'
 # probably a better way to do this too (pass $TOOL_PREFIX)
 osx_renamer = Builder(action = './renamer.py ' + os.environ.get('PWD') + '/' + lib_path + '/ @loader_path/ "$TOOL_PREFIX" $SOURCE', )
-env = Environment(variables=opts, BUILDERS={'OSXRename':osx_renamer})
+env = Environment(variables=opts, BUILDERS={'OSXRename':osx_renamer}, CFLAGS='-std=gnu11')
 
 if env['toolchainbin']:
     env.PrependENVPath('PATH', env['toolchainbin'])

--- a/SConstruct
+++ b/SConstruct
@@ -29,8 +29,7 @@ output_path = '#bin/' + env['platform'] + '/'
 if env['debug']:
     env.Append(CPPFLAGS=['-g'])
 
-if env['platform'] in ['x11', 'win64']:
-    env.Append(LIBPATH=[lib_path])
+env.Append(LIBPATH=[lib_path])
 if env['platform'] == 'x11':
     env.Append(RPATH=env.Literal('\$$ORIGIN'))
 

--- a/SConstruct
+++ b/SConstruct
@@ -9,20 +9,22 @@ opts.Add(BoolVariable('test','copy output to test project',True))
 opts.Add(EnumVariable('platform','can be osx, linux (x11) or windows (win64)','',('osx','x11','win64'),
                                         map={'linux':'x11','windows':'win64'}))
 opts.Add(PathVariable('toolchainbin', 'Path to the cross compiler toolchain bin directory. Only needed cross compiling and the toolchain isn\'t installed.', '', PathVariable.PathAccept))
+opts.Add(PathVariable('thirdparty', 'Path containing the ffmpeg libs', 'thirdparty', PathVariable.PathAccept))
+opts.Add(PathVariable('prefix', 'Path where the output lib will be installed', '', PathVariable.PathAccept))
 opts.Add(EnumVariable('darwinver', 'Darwin SDK version. (if cross compiling from linux to osx)', '15', [str(v) for v in range(11, 19 + 1)]))
 
 #probably a better way to do this instead of creating Enviroment() twice
 early_env=Environment(variables=opts, BUILDERS={})
-prefix = 'thirdparty/' + early_env['platform']
-lib_path = prefix + '/lib'
-include_path = prefix + '/include'
+lib_prefix = early_env['thirdparty'] + '/' + early_env['platform']
+lib_path = lib_prefix + '/lib'
+include_path = lib_prefix + '/include'
 # probably a better way to do this too (pass $TOOL_PREFIX)
 osx_renamer = Builder(action = './renamer.py ' + os.environ.get('PWD') + '/' + lib_path + '/ @loader_path/ "$TOOL_PREFIX" $SOURCE', )
 env = Environment(variables=opts, BUILDERS={'OSXRename':osx_renamer})
 
 if env['toolchainbin']:
     env.PrependENVPath('PATH', env['toolchainbin'])
-output_path = '#bin/' + env['platform']+ '/'
+output_path = '#bin/' + env['platform'] + '/'
 
 if env['debug']:
     env.Append(CPPFLAGS=['-g'])
@@ -36,7 +38,13 @@ env.Append(CPPPATH=['#' + include_path + '/'])
 env.Append(CPPPATH=['#godot_include'])
 
 from glob import glob
-ffmpeg_dylibs = glob(lib_path + '/*.dylib')
+globs = {
+    'x11': '*.so.[0-9]*',
+    'win64': '../bin/*-[0-9]*.dll',
+    'osx': '*.[0-9]*.dylib'
+}
+
+ffmpeg_dylibs = glob(lib_path + '/' + globs[env['platform']])
 
 installed_dylib = []
 for dylib in ffmpeg_dylibs:
@@ -86,7 +94,9 @@ output_dylib = env.SharedLibrary(output_path+'gdnative_videodecoder',sources)
 if env['platform'] == 'osx':
     env.OSXRename(None, output_dylib)
 
-if env['test']:
-    for dylib in installed_dylib:
-        env.Install('#test/addons/'+output_path[1:],dylib)
-    env.Install('#test/addons/'+output_path[1:], output_dylib)
+if env['prefix']:
+    path = env['prefix'] + '/' + env['platform'] + '/'
+    print('PREFIX %s %s' % (path, output_dylib + ffmpeg_dylibs))
+    Default(env.Install(path, ffmpeg_dylibs + output_dylib))
+elif env['test']:
+    env.Install('#test/addons/' + output_path[1:], output_dylib + ffmpeg_dylibs)

--- a/build_gdnative.sh.example
+++ b/build_gdnative.sh.example
@@ -38,28 +38,16 @@ if [[ "$1" != "--no-libs" ]]; then
     pushd contrib/ffmpeg-static
         set -x
         ./build.sh -B -T "$TARGET_DIR/x11" -j $JOBS
-        mkdir -p "$ADDON_BIN_DIR/x11"
-        cp -a $TARGET_DIR/x11/lib/* "$ADDON_BIN_DIR/x11"
         ./build.sh -B -p windows -T "$TARGET_DIR/win64" -j $JOBS
-        mkdir -p "$ADDON_BIN_DIR/win64"
-        cp $TARGET_DIR/win64/bin/* "$ADDON_BIN_DIR/win64"
         ./build.sh -B -p darwin -T "$TARGET_DIR/osx" -j $JOBS
-        mkdir -p "$ADDON_BIN_DIR/osx"
-        cp -a $TARGET_DIR/osx/lib/* "$TARGET_DIR/osx"
         set +x
-
     popd
 fi
 pushd contrib/godot-videodecoder
     set -x
-    scons platform=x11
-    cp -a $PLUGIN_BIN_DIR/x11/* "$ADDON_BIN_DIR/x11"
-    scons platform=windows
-    cp $PLUGIN_BIN_DIR/win64/* "$ADDON_BIN_DIR/win64"
+    scons platform=x11 prefix="$ADDON_BIN_DIR"
+    scons platform=windows prefix="$ADDON_BIN_DIR"
     # NOTE: -j doesn't work with this platform
-    scons platform=osx toolchainbin=$OSXCROSS_BIN_DIR
-    cp -a $PLUGIN_BIN_DIR/osx/* "$ADDON_BIN_DIR/osx"
-    # remove symlinks since we don't need them.
-    find $PLUGIN_BIN_DIR -type l -exec rm {} \;
+    scons platform=osx toolchainbin=$OSXCROSS_BIN_DIR prefix="$ADDON_BIN_DIR"
     set +x
 popd

--- a/test/addons/videodecoder.gdnlib
+++ b/test/addons/videodecoder.gdnlib
@@ -14,5 +14,5 @@ X11.64="res://addons/bin/x11/libgdnative_videodecoder.so"
 [dependencies]
 
 OSX.64=[ "res://addons/bin/osx/libavformat.58.dylib", "res://addons/bin/osx/libavutil.56.dylib", "res://addons/bin/osx/libavcodec.58.dylib", "res://addons/bin/osx/libswscale.5.dylib", "res://addons/bin/osx/libswresample.3.dylib" ]
-Windows.64=[ "res://addons/bin/win64/avformat-58.dll", "res://addons/bin/win64/avutil-56.dll", "res://addons/bin/win64/avcodec-58.dll", "res://addons/bin/win64/swscale-5.dll", "res://addons/bin/win64/swresample-3.dll" ]
+Windows.64=[ "res://addons/bin/win64/avformat-58.dll", "res://addons/bin/win64/avutil-56.dll", "res://addons/bin/win64/avcodec-58.dll", "res://addons/bin/win64/swscale-5.dll", "res://addons/bin/win64/swresample-3.dll", "res://addons/bin/win64/libwinpthread-1.dll" ]
 X11.64=[ "res://addons/bin/x11/libavformat.so.58", "res://addons/bin/x11/libavutil.so.56", "res://addons/bin/x11/libavcodec.so.58", "res://addons/bin/x11/libswscale.so.5", "res://addons/bin/x11/libswresample.so.3" ]


### PR DESCRIPTION
To decode the audio frames correctly:
Check the `pts` value (presentation timestamp) and either skip audio frames or hold onto them until the timestamp is within ~1 game frame, then feed them into the buffer.

To prevent frame dropping from affecting game performance:
Mark the time when get_videoframe is called, while dropping frames check the elapsed time and stop decoding frames if too much time has elapesd (hard coded at 10ms currently)
This isn't really supported by the VideoStreamGdnative interface! The workaround is to lie about the video position during `update()`. If we are dropping frames then we will tell godot that the video time is whatever it expects and it will stop calling `get_videoframe()`.

Also lots of cleanup of stray printfs, debugging information etc.

ALSO: Fix for osxcross build and include libwinpthread-1.dll for windows