### PR TITLE
Fix Docker builds. Allow plugin build in windows via MSVC. Release builds via Github Actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
-          draft: true
+          draft: false
           prerelease: true
       - name: Upload Release Asset
         id: upload-release-asset

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,40 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - '*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  build:
+    name: Upload Release Assets
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+            submodules: recursive
+      - name: Build for windows/x11
+        run: |
+          PLATFORMS=win64,x11 ./build_gdnative.sh
+          zip -r target.zip target
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: true
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./target.zip
+          asset_name: target.zip
+          asset_content_type: application/zip`

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
             submodules: recursive
       - name: Build for windows/x11
         run: |
-          PLATFORMS=win64,x11 ./build_gdnative.sh
+          PLATFORMS=win64,x11,win32,x11_32 ./build_gdnative.sh
           zip -r target.zip target
       - name: Create Release
         id: create_release

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ thirdparty/
 .test/addons/bin
 *.obj
 *.dll
+/target

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ thirdparty/
 .import/
 .DS_Store
 .test/addons/bin
+*.obj
+*.dll

--- a/Dockerfile.osx
+++ b/Dockerfile.osx
@@ -3,16 +3,20 @@ FROM godot-videodecoder-ubuntu-bionic:latest
 WORKDIR /opt/godot-videodecoder/ffmpeg-static
 COPY ./ffmpeg-static .
 
-ENV FINAL_TARGET_DIR=/opt/target
-ENV THIRDPARTY_DIR=/opt/godot-videodecoder/thirdparty
 ENV OSXCROSS_ROOT=/opt/osxcross
 ENV OSXCROSS_BIN_DIR=$OSXCROSS_ROOT/target/bin
-ENV PLUGIN_BIN_DIR=/opt/godot-videodecoder/bin
-ARG JOBS=1
 
-
+# download dependencies
 RUN ./build.sh -d -p darwin
+
+ARG JOBS=1
+ENV JOBS=$JOBS
+ENV THIRDPARTY_DIR=/opt/godot-videodecoder/thirdparty
 RUN ./build.sh -B -p darwin -T "$THIRDPARTY_DIR/osx" -j $JOBS
+
+ENV FINAL_TARGET_DIR=/opt/target
+ENV PLUGIN_BIN_DIR=/opt/godot-videodecoder/bin
+
 WORKDIR /opt/godot-videodecoder
 
 COPY . .

--- a/Dockerfile.ubuntu-bionic
+++ b/Dockerfile.ubuntu-bionic
@@ -1,4 +1,5 @@
-FROM ubuntu:bionic
+FROM ubuntu:bionic-20200403
+
 
 # build environment for osxcross
 

--- a/Dockerfile.ubuntu-bionic
+++ b/Dockerfile.ubuntu-bionic
@@ -6,7 +6,7 @@ FROM ubuntu:bionic-20200403
 # download XCode (7.3.1) from https://developer.apple.com/download/more/?name=Xcode%207.3.1
 # extract the sdk tarball using the following instructions:
 # https://github.com/tpoechtrager/osxcross#packing-the-sdk-on-linux---method-2-works-up-to-xcode-73
-ARG XCODE_SDK=./thirdparty/MacOSX10.11.sdk.tar.xz
+ARG XCODE_SDK=
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -28,7 +28,7 @@ RUN git clone --depth=1 https://github.com/tpoechtrager/osxcross.git /opt/osxcro
 COPY ./darwin_sdk/* /opt/osxcross/tarballs/
 
 RUN cmake --version
-RUN cd /opt/osxcross && UNATTENDED=1 ./build.sh
-RUN echo "building gcc"; cd /opt/osxcross && UNATTENDED=1 ./build_gcc.sh
+RUN [ -z "$XCODE_SDK" ] || (cd /opt/osxcross && UNATTENDED=1 ./build.sh) 
+RUN [ -z "$XCODE_SDK" ] || (echo "building gcc"; cd /opt/osxcross && UNATTENDED=1 ./build_gcc.sh)
 
 WORKDIR /opt/godot-videodecoder/

--- a/Dockerfile.ubuntu-xenial
+++ b/Dockerfile.ubuntu-xenial
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:xenial-20200326
 
 #build environment for ubuntu with older glibc
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -2,19 +2,20 @@ FROM godot-videodecoder-ubuntu-bionic:latest
 
 WORKDIR /opt/godot-videodecoder/ffmpeg-static
 COPY ./ffmpeg-static .
+# download dependencies
+RUN ./build.sh -d -p win32
+
+ARG JOBS=1
+ENV JOBS=$JOBS
+ENV THIRDPARTY_DIR=/opt/godot-videodecoder/thirdparty
+RUN ./build.sh -B -p win32 -T "$THIRDPARTY_DIR/win32" -j $JOBS
 
 ENV FINAL_TARGET_DIR=/opt/target
-ENV THIRDPARTY_DIR=/opt/godot-videodecoder/thirdparty
 ENV PLUGIN_BIN_DIR=/opt/godot-videodecoder/bin
-ARG JOBS=1
 
-
-RUN ./build.sh -d -p win32
-RUN ./build.sh -B -p win32 -T "$THIRDPARTY_DIR/win32" -j $JOBS
 WORKDIR /opt/godot-videodecoder
 
 COPY . .
 RUN scons -c platform=win32
-
 RUN scons platform=win32 prefix="${FINAL_TARGET_DIR}"
 

--- a/Dockerfile.win64
+++ b/Dockerfile.win64
@@ -2,18 +2,19 @@ FROM godot-videodecoder-ubuntu-bionic:latest
 
 WORKDIR /opt/godot-videodecoder/ffmpeg-static
 COPY ./ffmpeg-static .
+# download dependencies
+RUN ./build.sh -d -p windows
+
+ARG JOBS=1
+ENV JOBS=$JOBS
+ENV THIRDPARTY_DIR=/opt/godot-videodecoder/thirdparty
+RUN ./build.sh -B -p windows -T "$THIRDPARTY_DIR/win64" -j $JOBS
 
 ENV FINAL_TARGET_DIR=/opt/target
-ENV THIRDPARTY_DIR=/opt/godot-videodecoder/thirdparty
 ENV PLUGIN_BIN_DIR=/opt/godot-videodecoder/bin
-ARG JOBS=1
 
-
-RUN ./build.sh -d -p windows
-RUN ./build.sh -B -p windows -T "$THIRDPARTY_DIR/win64" -j $JOBS
 WORKDIR /opt/godot-videodecoder
 
 COPY . .
 RUN scons -c platform=windows
-
 RUN scons platform=windows prefix="${FINAL_TARGET_DIR}"

--- a/Dockerfile.x11
+++ b/Dockerfile.x11
@@ -2,14 +2,17 @@ FROM godot-videodecoder-ubuntu-xenial:latest
 
 WORKDIR /opt/godot-videodecoder/ffmpeg-static
 COPY ./ffmpeg-static .
+# download dependencies
+RUN ./build.sh -d
+
+ARG JOBS=1
+ENV JOBS=$JOBS
+ENV THIRDPARTY_DIR=/opt/godot-videodecoder/thirdparty
+RUN ./build.sh -B -T "$THIRDPARTY_DIR/x11" -j $JOBS
 
 ENV FINAL_TARGET_DIR=/opt/target
-ENV THIRDPARTY_DIR=/opt/godot-videodecoder/thirdparty
 ENV PLUGIN_BIN_DIR=/opt/godot-videodecoder/bin
-ARG JOBS=1
 
-RUN ./build.sh -d
-RUN ./build.sh -B -T "$THIRDPARTY_DIR/x11" -j $JOBS
 WORKDIR /opt/godot-videodecoder
 
 COPY . .

--- a/Dockerfile.x11_32
+++ b/Dockerfile.x11_32
@@ -1,5 +1,7 @@
 FROM godot-videodecoder-ubuntu-xenial:latest
 
+RUN apt install -y libc6-dev-i386
+
 WORKDIR /opt/godot-videodecoder/ffmpeg-static
 COPY ./ffmpeg-static .
 # download dependencies

--- a/Dockerfile.x11_32
+++ b/Dockerfile.x11_32
@@ -2,14 +2,17 @@ FROM godot-videodecoder-ubuntu-xenial:latest
 
 WORKDIR /opt/godot-videodecoder/ffmpeg-static
 COPY ./ffmpeg-static .
+# download dependencies
+RUN ./build.sh -d
+
+ARG JOBS=1
+ENV JOBS=$JOBS
+ENV THIRDPARTY_DIR=/opt/godot-videodecoder/thirdparty
+RUN ./build.sh -B -T "$THIRDPARTY_DIR/x11_32" -j $JOBS
 
 ENV FINAL_TARGET_DIR=/opt/target
-ENV THIRDPARTY_DIR=/opt/godot-videodecoder/thirdparty
 ENV PLUGIN_BIN_DIR=/opt/godot-videodecoder/bin
-ARG JOBS=1
 
-RUN ./build.sh -d
-RUN ./build.sh -B -T "$THIRDPARTY_DIR/x11_32" -j $JOBS
 WORKDIR /opt/godot-videodecoder
 
 COPY . .

--- a/Dockerfile.x11_32
+++ b/Dockerfile.x11_32
@@ -1,16 +1,17 @@
 FROM godot-videodecoder-ubuntu-xenial:latest
+RUN dpkg --add-architecture i386; apt update
 
-RUN apt install -y libc6-dev-i386
+RUN apt install -y libc6-dev-i386 libgl1-mesa-dev:i386
 
 WORKDIR /opt/godot-videodecoder/ffmpeg-static
 COPY ./ffmpeg-static .
 # download dependencies
-RUN ./build.sh -d
+RUN ./build.sh -d -p x11_32
 
 ARG JOBS=1
 ENV JOBS=$JOBS
 ENV THIRDPARTY_DIR=/opt/godot-videodecoder/thirdparty
-RUN ./build.sh -B -T "$THIRDPARTY_DIR/x11_32" -j $JOBS
+RUN ./build.sh -B -p x11_32 -T "$THIRDPARTY_DIR/x11_32" -j $JOBS
 
 ENV FINAL_TARGET_DIR=/opt/target
 ENV PLUGIN_BIN_DIR=/opt/godot-videodecoder/bin

--- a/README.md
+++ b/README.md
@@ -5,9 +5,18 @@ using the [FFmpeg](https://ffmpeg.org) library for codecs.
 
 **A GSoC 2018 Project**
 
-This project is set up so that a game developer can build x11, windows and osx plugin libraries with a single script. The build enviroment has been dockerized for portability. Building has been tested on macos (catalina) and linux.
+This project is set up so that a game developer can build x11, windows and osx plugin libraries with a single script. The build enviroment has been dockerized for portability. Building has been tested on linux and windows 10 pro with WSL2.
 
 The most difficult part of building the plugin libraries is extracting the macos sdk from the XCode download since it [can't be distributed directly](https://www.apple.com/legal/sla/docs/xcode.pdf).
+
+**Releases**
+
+Release builds should automatically be available [here](/releases/latest) on github.
+
+**Media Support**
+
+The current dockerized ffmpeg build supports VP9 decoding only. Support for other decoders could be added, PRs are welcome.
+Patent encumbered codecs like [h264/h265](https://www.mpegla.com/wp-content/uploads/avcweb.pdf) will always be missing in the automatic builds due to copyright issues and the [cost of distributing pre-built binaries](https://jina-liu.medium.com/settle-your-questions-about-h-264-license-cost-once-and-for-all-hopefully-a058c2149256#5e65).
 
 ## Instructions to build with docker
 
@@ -47,3 +56,5 @@ TODO:
 * instructions for running the test project
 * Add a benchmark to the test project
 * Input for additional ffmpeg flags/deps
+* Re-enable additional media formats with the ability to build only a subset
+* OSX build in releases via github actions

--- a/SConstruct
+++ b/SConstruct
@@ -30,7 +30,8 @@ pwd = os.environ.get('PWD') or os.getcwd()
 
 osx_renamer = Builder(action = './renamer.py ' + pwd + '/' + lib_path + '/ @loader_path/ "$TOOL_PREFIX" $SOURCE', )
 
-env = Environment(variables=opts, BUILDERS={'OSXRename':osx_renamer}, CFLAGS='/WX' if msvc_build else '-std=gnu11', TARGET_ARCH='x86_64')
+env = Environment(variables=opts, BUILDERS={'OSXRename':osx_renamer}, CFLAGS='/WX' if msvc_build else '-std=gnu11')
+env.Append(TARGET_ARCH='i386' if env['platform'].endswith('32') else 'x86_64')
 
 if env['toolchainbin']:
     env.PrependENVPath('PATH', env['toolchainbin'])
@@ -47,7 +48,9 @@ if env['platform'] == 'x11':
 if env['platform'] == 'x11_32':
     env.Append(RPATH=env.Literal('\$$ORIGIN'))
     # statically link glibc
-    env.Append(LIBS=[File('/usr/lib/i386-linux-gnu/libc_nonshared.a')])
+    env.Append(LIBS=[File('/usr/lib32/libc_nonshared.a')])
+if env['platform'] == 'win32':
+    env.Append(LIBS=['pthread'])
 
 env.Append(CPPPATH=['#' + include_path + '/'])
 env.Append(CPPPATH=['#godot_include'])

--- a/SConstruct
+++ b/SConstruct
@@ -30,7 +30,7 @@ pwd = os.environ.get('PWD') or os.getcwd()
 
 osx_renamer = Builder(action = './renamer.py ' + pwd + '/' + lib_path + '/ @loader_path/ "$TOOL_PREFIX" $SOURCE', )
 
-env = Environment(variables=opts, BUILDERS={'OSXRename':osx_renamer}, CFLAGS='' if msvc_build else '-std=gnu11', TARGET_ARCH='x86_64')
+env = Environment(variables=opts, BUILDERS={'OSXRename':osx_renamer}, CFLAGS='/WX' if msvc_build else '-std=gnu11', TARGET_ARCH='x86_64')
 
 if env['toolchainbin']:
     env.PrependENVPath('PATH', env['toolchainbin'])
@@ -114,7 +114,11 @@ if msvc_build:
 
 sources = list(map(lambda x: '#'+x, glob('src/*.c')))
 
-output_dylib = env.SharedLibrary(output_path+'gdnative_videodecoder',sources)
+# msvc doesn't prefix dll files with 'lib'
+libprefix = 'lib' if msvc_build else ''
+if env['debug']:
+    env['PDB'] = output_path+libprefix+'gdnative_videodecoder.pdb'
+output_dylib = env.SharedLibrary(output_path+libprefix+'gdnative_videodecoder',sources)
 
 if env['platform'] == 'osx':
     env.OSXRename(None, output_dylib)

--- a/SConstruct
+++ b/SConstruct
@@ -36,7 +36,7 @@ if env['toolchainbin']:
     env.PrependENVPath('PATH', env['toolchainbin'])
 output_path = '#bin/' + env['platform'] + '/'
 
-if env['debug'] and msvc_build:
+if env['debug'] and not msvc_build:
     env.Append(CPPFLAGS=['-g'])
 
 env.Append(LIBPATH=[lib_path])

--- a/SConstruct
+++ b/SConstruct
@@ -49,6 +49,8 @@ if env['platform'] == 'x11_32':
     env.Append(RPATH=env.Literal('\$$ORIGIN'))
     # statically link glibc
     env.Append(LIBS=[File('/usr/lib32/libc_nonshared.a')])
+    env.Append(CFLAGS=['-m32'])
+    env.Append(LINKFLAGS=['-m32'])
 if env['platform'] == 'win32':
     env.Append(LIBS=['pthread'])
 

--- a/build_gdnative.sh
+++ b/build_gdnative.sh
@@ -16,72 +16,149 @@
 
 DIR="$(cd $(dirname "$0") && pwd)"
 ADDON_BIN_DIR=${ADDON_BIN_DIR:-$DIR/target}
+THIRDPARTY_DIR=${THIRDPARTY_DIR:-$DIR/thirdparty}
 # COPY can't use variables, so pre-copy the file
 XCODE_SDK_FOR_COPY=./darwin_sdk/MacOSX10.11.sdk.tar.xz
 XCODE_SDK="${XCODE_SDK:-$XCODE_SDK_FOR_COPY}"
 JOBS=${JOBS:-4}
+
+if [ -z "$PLATFORMS" ]; then
+    PLATFORM_LIST=(win64 osx x11 win32 x11_32)
+else
+    IFS=',' read -r -a PLATFORM_LIST <<< "$PLATFORMS"
+fi
+declare -A PLATMAP
+for p in "${PLATFORM_LIST[@]}"; do
+    PLATMAP[$p]=1
+done
+
+plat_win64=${PLATMAP['win64']}
+plat_win32=${PLATMAP['win32']}
+plat_osx=${PLATMAP['osx']}
+plat_x11=${PLATMAP['x11']}
+plat_x11_32=${PLATMAP['x11_32']}
+plat_win_any=${PLATMAP['win64']}${PLATMAP['win32']}
+plat_x11_any=${PLATMAP['x11']}${PLATMAP['x11_32']}
+
 if [ -f /proc/cpuinfo ]; then
-    JOBS=$(echo "$(cat /proc/cpuinfo  | grep processor |wc -l) - 1" |  bc -l)
+    JOBS=$(expr $(cat /proc/cpuinfo  | grep processor | wc -l) - 1)
 elif type sysctl > /dev/null; then
     # osx logical cores
     JOBS=$(sysctl -n hw.ncpu)
 else
     echo "Unable to determine how many logical cores are available."
-    echo "Using JOBS=$JOBS"
 fi
 echo "Using JOBS=$JOBS"
 
 #img_version="$(git describe 2>/dev/null || git rev-parse HEAD)"
 # TODO : pass in img_version like https://github.com/godotengine/build-containers/blob/master/Dockerfile.osx#L1
-# trusty is for linux builds
-echo "XCODE_SDK=$XCODE_SDK"
-if [ ! -f "$XCODE_SDK" ]; then
-    ls -l "$XCODE_SDK"
-    echo "Unable to find $XCODE_SDK"
-    exit 1
-fi
-if [ ! "$XCODE_SDK" = "$XCODE_SDK_FOR_COPY" ]; then
-    mkdir -p $(dirname "$XCODE_SDK_FOR_COPY")
-    cp "$XCODE_SDK" "$XCODE_SDK_FOR_COPY"
+
+if [ $plat_osx ]; then
+    echo "XCODE_SDK=$XCODE_SDK"
+    if [ ! -f "$XCODE_SDK" ]; then
+        ls -l "$XCODE_SDK"
+        echo "Unable to find $XCODE_SDK"
+        exit 1
+    fi
+    if [ ! "$XCODE_SDK" = "$XCODE_SDK_FOR_COPY" ]; then
+        mkdir -p $(dirname "$XCODE_SDK_FOR_COPY")
+        cp "$XCODE_SDK" "$XCODE_SDK_FOR_COPY"
+    fi
 fi
 
 set -e
 # ideally we'd run these at the same time but ... https://github.com/moby/moby/issues/2776
-docker build ./ -f Dockerfile.ubuntu-xenial -t "godot-videodecoder-ubuntu-xenial"
-docker build ./ -f Dockerfile.ubuntu-bionic -t "godot-videodecoder-ubuntu-bionic" \
+if [ $plat_x11_any ]; then
+    docker build ./ -f Dockerfile.ubuntu-xenial -t "godot-videodecoder-ubuntu-xenial"
+fi
+
+# bionic is for cross compiles, use xenial for linux
+# (for ubuntu 16 compatibility even though it's outdated already)
+if [ $plat_osx ]; then
+    echo "building with xcode sdk"
+    docker build ./ -f Dockerfile.ubuntu-bionic -t "godot-videodecoder-ubuntu-bionic" \
     --build-arg XCODE_SDK=$XCODE_SDK
-docker build ./ -f Dockerfile.osx --build-arg JOBS=$JOBS -t "godot-videodecoder-osx"
-docker build ./ -f Dockerfile.x11 --build-arg JOBS=$JOBS -t "godot-videodecoder-x11"
-docker build ./ -f Dockerfile.x11_32 --build-arg JOBS=$JOBS -t "godot-videodecoder-x11_32"
-docker build ./ -f Dockerfile.win64 --build-arg JOBS=$JOBS -t "godot-videodecoder-win64"
-docker build ./ -f Dockerfile.win32 --build-arg JOBS=$JOBS -t "godot-videodecoder-win32"
+elif [ $plat_win_any ]; then
+    echo "building without xcode sdk"
+    docker build ./ -f Dockerfile.ubuntu-bionic -t "godot-videodecoder-ubuntu-bionic"
+fi
+
+if [ $plat_osx ]; then
+    docker build ./ -f Dockerfile.osx --build-arg JOBS=$JOBS -t "godot-videodecoder-osx"
+fi
+if [ $plat_x11 ]; then
+    docker build ./ -f Dockerfile.x11 --build-arg JOBS=$JOBS -t "godot-videodecoder-x11"
+fi
+if [ $plat_x11_32 ]; then
+    docker build ./ -f Dockerfile.x11_32 --build-arg JOBS=$JOBS -t "godot-videodecoder-x11_32"
+fi
+if [ $plat_win64 ]; then
+    docker build ./ -f Dockerfile.win64 --build-arg JOBS=$JOBS -t "godot-videodecoder-win64"
+fi
+if [ $plat_win32 ]; then
+    docker build ./ -f Dockerfile.win32 --build-arg JOBS=$JOBS -t "godot-videodecoder-win32"
+fi
 
 set -x
 # precreate the target directory because otherwise
 # docker cp will copy x11/* -> $ADDON_BIN_DIR/* instead of x11/* -> $ADDON_BIN_DIR/x11/*
 mkdir -p $ADDON_BIN_DIR/
+# copy the thirdparty dir in case you want to try building the lib against the ffmpeg libs directly e.g. in MSVC
+mkdir -p $THIRDPARTY_DIR
 
-echo "extracting $ADDON_BIN_DIR/x11"
-id=$(docker create godot-videodecoder-x11)
-docker cp $id:/opt/target/x11 $ADDON_BIN_DIR/
-docker rm -v $id
+# TODO: this should be a loop over all the platforms
+if [ $plat_x11 ]; then
+    echo "extracting $ADDON_BIN_DIR/x11"
+    id=$(docker create godot-videodecoder-x11)
+    docker cp $id:/opt/target/x11 $ADDON_BIN_DIR/
+    mkdir -p $THIRDPARTY_DIR/x11
 
-echo "extracting $ADDON_BIN_DIR/x11_32"
-id=$(docker create godot-videodecoder-x11_32)
-docker cp $id:/opt/target/x11_32 $ADDON_BIN_DIR/
-docker rm -v $id
+    # tar because copying a symlink on windows will fail if you don't run as administrator
+    docker cp $id:/opt/godot-videodecoder/thirdparty/x11 - | tar -xC $THIRDPARTY_DIR/x11/
+    docker rm -v $id
+fi
 
-echo "extracting $ADDON_BIN_DIR/osx"
-id=$(docker create godot-videodecoder-osx)
-docker cp $id:/opt/target/osx $ADDON_BIN_DIR/
-docker rm -v $id
+if [ $plat_x11 ]; then
+    echo "extracting $ADDON_BIN_DIR/x11"
+    echo "extracting $ADDON_BIN_DIR/x11_32"
+    id=$(docker create godot-videodecoder-x11_32)
+    docker cp $id:/opt/target/x11_32 $ADDON_BIN_DIR/
 
-echo "extracting $ADDON_BIN_DIR/win64"
-id=$(docker create godot-videodecoder-win64)
-docker cp $id:/opt/target/win64 $ADDON_BIN_DIR/
-docker rm -v $id
+    mkdir -p $THIRDPARTY_DIR/x11_32
+    # tar because copying a symlink on windows will fail if you don't run as administrator
+    docker cp $id:/opt/godot-videodecoder/thirdparty/x11_32 - | tar -xC $THIRDPARTY_DIR/x11_32/
+    docker rm -v $id
+fi
 
-echo "extracting $ADDON_BIN_DIR/win32"
-id=$(docker create godot-videodecoder-win32)
-docker cp $id:/opt/target/win32 $ADDON_BIN_DIR/
-docker rm -v $id
+if [ $plat_osx ]; then
+    echo "extracting $ADDON_BIN_DIR/osx"
+    id=$(docker create godot-videodecoder-osx)
+    docker cp $id:/opt/target/osx $ADDON_BIN_DIR/
+
+    mkdir -p $THIRDPARTY_DIR/osx
+    # tar because copying a symlink on windows will fail if you don't run as administrator
+    docker cp $id:/opt/godot-videodecoder/thirdparty/osx - | tar -xC $THIRDPARTY_DIR/osx/
+    docker rm -v $id
+fi
+
+if [ $plat_win64 ]; then
+    echo "extracting $ADDON_BIN_DIR/win64"
+    id=$(docker create godot-videodecoder-win64)
+    docker cp $id:/opt/target/win64 $ADDON_BIN_DIR/
+
+    mkdir -p $THIRDPARTY_DIR/win64
+    # tar because copying a symlink on windows will fail if you don't run as administrator
+    docker cp $id:/opt/godot-videodecoder/thirdparty/win64 - | tar -xC $THIRDPARTY_DIR/win64/
+    docker rm -v $id
+fi
+
+if [ $plat_win32 ]; then
+    echo "extracting $ADDON_BIN_DIR/win32"
+    id=$(docker create godot-videodecoder-win32)
+    docker cp $id:/opt/target/win32 $ADDON_BIN_DIR/
+
+    mkdir -p $THIRDPARTY_DIR/win32
+    # tar because copying a symlink on windows will fail if you don't run as administrator
+    docker cp $id:/opt/godot-videodecoder/thirdparty/win64 - | tar -xC $THIRDPARTY_DIR/win32/
+    docker rm -v $id
+fi

--- a/build_gdnative.sh
+++ b/build_gdnative.sh
@@ -32,6 +32,8 @@ for p in "${PLATFORM_LIST[@]}"; do
     PLATMAP[$p]=1
 done
 
+echo "Building for ${PLATFORM_LIST[@]}"
+
 plat_win64=${PLATMAP['win64']}
 plat_win32=${PLATMAP['win32']}
 plat_osx=${PLATMAP['osx']}
@@ -84,15 +86,18 @@ elif [ $plat_win_any ]; then
 fi
 
 if [ $plat_osx ]; then
+    echo "Building for OSX"
     docker build ./ -f Dockerfile.osx --build-arg JOBS=$JOBS -t "godot-videodecoder-osx"
 fi
 if [ $plat_x11 ]; then
+    echo "Building for X11"
     docker build ./ -f Dockerfile.x11 --build-arg JOBS=$JOBS -t "godot-videodecoder-x11"
 fi
 if [ $plat_x11_32 ]; then
     docker build ./ -f Dockerfile.x11_32 --build-arg JOBS=$JOBS -t "godot-videodecoder-x11_32"
 fi
 if [ $plat_win64 ]; then
+    echo "Building for Win64"
     docker build ./ -f Dockerfile.win64 --build-arg JOBS=$JOBS -t "godot-videodecoder-win64"
 fi
 if [ $plat_win32 ]; then

--- a/build_gdnative.sh
+++ b/build_gdnative.sh
@@ -150,6 +150,16 @@ fi
 
 if [ $plat_x11 ]; then
     echo "extracting $ADDON_BIN_DIR/x11"
+    id=$(docker create godot-videodecoder-x11)
+    docker cp $id:/opt/target/x11 $ADDON_BIN_DIR/
+
+    mkdir -p $THIRDPARTY_DIR/x11
+    # tar because copying a symlink on windows will fail if you don't run as administrator
+    docker cp $id:/opt/godot-videodecoder/thirdparty/x11 - | tar -xC $THIRDPARTY_DIR/
+    docker rm -v $id
+fi
+
+if [ $plat_x11_32 ]; then
     echo "extracting $ADDON_BIN_DIR/x11_32"
     id=$(docker create godot-videodecoder-x11_32)
     docker cp $id:/opt/target/x11_32 $ADDON_BIN_DIR/

--- a/build_gdnative.sh
+++ b/build_gdnative.sh
@@ -136,6 +136,10 @@ mkdir -p $ADDON_BIN_DIR/
 # copy the thirdparty dir in case you want to try building the lib against the ffmpeg libs directly e.g. in MSVC
 mkdir -p $THIRDPARTY_DIR
 
+if [ "$(uname -o)" = "Msys" ]; then
+    export MSYS=winsymlinks:native
+fi
+
 # TODO: this should be a loop over all the platforms
 if [ $plat_x11 ]; then
     echo "extracting $ADDON_BIN_DIR/x11"
@@ -144,7 +148,7 @@ if [ $plat_x11 ]; then
     mkdir -p $THIRDPARTY_DIR/x11
 
     # tar because copying a symlink on windows will fail if you don't run as administrator
-    docker cp $id:/opt/godot-videodecoder/thirdparty/x11 - | tar -xC $THIRDPARTY_DIR/
+    docker cp -L $id:/opt/godot-videodecoder/thirdparty/x11 - | tar -xhC $THIRDPARTY_DIR/
     docker rm -v $id
 fi
 
@@ -155,7 +159,7 @@ if [ $plat_x11 ]; then
 
     mkdir -p $THIRDPARTY_DIR/x11
     # tar because copying a symlink on windows will fail if you don't run as administrator
-    docker cp $id:/opt/godot-videodecoder/thirdparty/x11 - | tar -xC $THIRDPARTY_DIR/
+    docker cp -L $id:/opt/godot-videodecoder/thirdparty/x11 - | tar -xhC $THIRDPARTY_DIR/
     docker rm -v $id
 fi
 
@@ -166,7 +170,7 @@ if [ $plat_x11_32 ]; then
 
     mkdir -p $THIRDPARTY_DIR/x11_32
     # tar because copying a symlink on windows will fail if you don't run as administrator
-    docker cp $id:/opt/godot-videodecoder/thirdparty/x11_32 - | tar -xC $THIRDPARTY_DIR/
+    docker cp -L $id:/opt/godot-videodecoder/thirdparty/x11_32 - | tar -xhC $THIRDPARTY_DIR/
     docker rm -v $id
 fi
 
@@ -177,7 +181,7 @@ if [ $plat_osx ]; then
 
     mkdir -p $THIRDPARTY_DIR/osx
     # tar because copying a symlink on windows will fail if you don't run as administrator
-    docker cp $id:/opt/godot-videodecoder/thirdparty/osx - | tar -xC $THIRDPARTY_DIR/
+    docker cp -L $id:/opt/godot-videodecoder/thirdparty/osx - | tar -xhC $THIRDPARTY_DIR/
     docker rm -v $id
 fi
 
@@ -188,7 +192,7 @@ if [ $plat_win64 ]; then
 
     mkdir -p $THIRDPARTY_DIR/win64
     # tar because copying a symlink on windows will fail if you don't run as administrator
-    docker cp $id:/opt/godot-videodecoder/thirdparty/win64 - | tar -xC $THIRDPARTY_DIR/
+    docker cp -L $id:/opt/godot-videodecoder/thirdparty/win64 - | tar -xhC $THIRDPARTY_DIR/
     docker rm -v $id
 fi
 
@@ -199,7 +203,7 @@ if [ $plat_win32 ]; then
 
     mkdir -p $THIRDPARTY_DIR/win32
     # tar because copying a symlink on windows will fail if you don't run as administrator
-    docker cp $id:/opt/godot-videodecoder/thirdparty/win32 - | tar -xC $THIRDPARTY_DIR/
+    docker cp -L $id:/opt/godot-videodecoder/thirdparty/win32 - | tar -xhC $THIRDPARTY_DIR/
     docker rm -v $id
 fi
 
@@ -207,6 +211,6 @@ if type tree 2> /dev/null; then
     tree $THIRDPARTY_DIR -L 2 -hD
     tree $ADDON_BIN_DIR -hD
 else
-    find $THIRDPARTY_DIR -print -maxdepth 2 -exec ls -lh {} \;
-    find $ADDON_BIN_DIR -print -maxdepth 1 -exec ls -lh {} \;
+    find $THIRDPARTY_DIR -maxdepth 2 -print -exec ls -lh {} \;
+    find $ADDON_BIN_DIR -maxdepth 1 -print -exec ls -lh {} \;
 fi

--- a/src/gdnative_videodecoder.c
+++ b/src/gdnative_videodecoder.c
@@ -552,7 +552,7 @@ godot_bool godot_videodecoder_open_file(void *p_data, void *file) {
 	if (input_format == NULL) {
 		_cleanup(data);
 		char msg[512] = {0};
-		snprintf(msg, sizeof(msg) - 1, "Format not recognized: %s (%s)", input_format->name, input_format->long_name);
+		snprintf(msg, sizeof(msg) - 1, "Format not recognized: %s (%s)", probe_data.filename, probe_data.mime_type);
 		api->godot_print_error(msg, "godot_videodecoder_open_file()", __FILE__, __LINE__);
 		return GODOT_FALSE;
 	}

--- a/src/gdnative_videodecoder.c
+++ b/src/gdnative_videodecoder.c
@@ -508,7 +508,7 @@ void godot_videodecoder_destructor(void *p_data) {
 const char **godot_videodecoder_get_supported_ext(int *p_count) {
 	_update_extensions();
 	*p_count = num_supported_ext;
-	return supported_ext;
+	return (const char **)supported_ext;
 }
 
 const char *godot_videodecoder_get_plugin_name(void) {

--- a/src/gdnative_videodecoder.c
+++ b/src/gdnative_videodecoder.c
@@ -89,7 +89,7 @@ extern const godot_videodecoder_interface_gdnative plugin_interface;
 
 static const char *plugin_name = "ffmpeg_videoplayer";
 static int num_supported_ext = 0;
-static const char **supported_ext = NULL;
+static char **supported_ext = NULL;
 
 /// Clock Setup function (used by get_ticks_usec)
 static uint64_t _clock_start = 0;
@@ -340,7 +340,7 @@ static void _update_extensions() {
 
 	list_t ext_list = set_create_list(sup_ext_set);
 	num_supported_ext = list_size(&ext_list);
-	supported_ext = (const char **)api->godot_alloc(sizeof(char *) * num_supported_ext);
+	supported_ext = (char **)api->godot_alloc(sizeof(char *) * num_supported_ext);
 	list_node_t *cur_node = ext_list.start;
 	int i = 0;
 	while (cur_node != NULL) {
@@ -865,7 +865,7 @@ retry:
 		// only discard frames for max_frame_drop_time ms or we'll slow down the game's main thread!
 		if (fabs(data->seek_time - data->time) > data->diff_tolerance * 10) {
 			char msg[512];
-			snprintf(msg, sizeof(msg) -1, "Slow CPU? Dropped  %d frames for %ldms frame dropped: %ld/%ld (%.1f%%) pts=%.1f t=%.1f",
+			snprintf(msg, sizeof(msg) -1, "Slow CPU? Dropped  %d frames for %"PRId64"ms frame dropped: %lu/%lu (%.1f%%) pts=%.1f t=%.1f",
 				(int)drop_count,
 				drop_duration,
 				data->drop_frame,


### PR DESCRIPTION
Use the tagged containers for the docker builds to make sure they don't change and the project will always build.
The scons build for the plugin itself can now be run in windows directly. This will build using MSVC and create .pbd files for debugging. (the ffmpeg libs are still pre-built via the dockerized build system and mingw)
Tagged commits will automatically generate releases on github via Github Actions.
Currently only X11 and Windows plugin libs are generated because of the redistribution limitations on the MacOS SDK.

Added support for the `PLATFORMS` environment variable while running `build_gdnative.sh`. This allows building for the specified platform(s) only. It's a comma delimited string, e.g. `PLATFORMS=win64,x11 ./build_gdnative.sh`